### PR TITLE
Update moksha-0.1.0.ebuild

### DIFF
--- a/x11-wm/moksha/moksha-0.1.0.ebuild
+++ b/x11-wm/moksha/moksha-0.1.0.ebuild
@@ -1,13 +1,26 @@
 EAPI=5
-inherit enlightenment
-DESCRIPTION="Moksha 0.1.0 window manager"
-SRC_URI="https://github.com/JeffHoogland/moksha/archive/${PV}.tar.gz"
-LICENSE="BSD-2"
-KEYWORDS="~amd64"
-SLOT="0.17"
+inherit autotools-utils
+EAPI=5
 
+if [[ ${PV} = 9999 ]]; then
+	inherit git-2
+fi
+
+DESCRIPTION="Moksha  window manager a fork of Enlightenment 17 with fixes"
+HOMEPAGE="https://github.com/vivien/i3blocks"
+if [[ ${PV} = 9999 ]]; then
+	EGIT_REPO_URI="https://github.com/JeffHoogland/${PN}.git"
+	EGIT_BOOTSTRAP=""
+	KEYWORDS=""
+else
+	SRC_URI="https://github.com/JeffHoogland/${PN}/archive/v${PV}.tar.gz -> {PN}-${PV}.tar.gz"
+	KEYWORDS="~amd64 ~x86"
+fi
+
+SLOT="0"
 IUSE="pam spell static-libs +udev ukit ${IUSE_E_MODULES}"
-
+S=${WORKDIR}/${P%%_*}
+# add normal Depends atoms. To Do... 
 RDEPEND="
   >=dev-libs/efl-1.15.1
 	>=dev-libs/e_dbus-1.7.10
@@ -15,21 +28,35 @@ RDEPEND="
 	x11-libs/xcb-util-keysyms"
 DEPEND="${RDEPEND}"
 
-S=${WORKDIR}/${P%%_*}
+AUTOTOOLS_IN_SOURCE_BUILD=1
 
-src_prepare() {
-	sed -i "s:1.7.10:1.7.9:g" configure.ac
-	eautoreconf
-	epatch "${FILESDIR}"/quickstart.diff
-	enlightenment_src_prepare
-}
+DOCS=(AUTHORS ChangeLog README "Read me.txt" TODO)
 
 src_configure() {
-	enlightenment_src_configure
+        local myeconfargs=(
+                $(use_enable debug)
+                $(use_with qt4)
+                $(use_enable threads multithreading)
+                $(use_with tiff)
+        )
+        autotools-utils_src_configure
+}
+src_prepare() {
+	# sed -i "s:1.7.10:1.7.9:g" configure.ac for Enlightenment however its a fork so unsure if nessisary.
+	# sed -i "s:1.7.10:1.7.9:g" configure.ac
+	epatch "${FILESDIR}"/quickstart.diff
+}
+src_compile() {
+        autotools-utils_src_compile
+        use doc && autotools-utils_src_compile docs
 }
 
 src_install() {
-	enlightenment_src_install
-	insinto /etc/enlightenment
-	newins "${FILESDIR}"/gentoo-sysactions.conf sysactions.conf
+        use doc && HTML_DOCS=("${BUILD_DIR}/apidocs/html/")
+        autotools-utils_src_install
+        if use examples; then
+                dobin "${BUILD_DIR}"/usr/bin/moksha/ \
+                newins "${FILESDIR}"/gentoo-sysactions.conf sysactions.conf
+                        || die 'dobin moksha failed'
+        fi
 }


### PR DESCRIPTION
still needs a we bit upstream is killing refs to Enlightement anyhow 

deps need be added. 
virtual/pkgconfig app-doc/doxygen dev-libs/openssl
https://packages.gentoo.org/packages  ... one of use will be looking these up for some time.... 
doxygen pkg-config libglib2.0-dev libssl-dev libpng12-dev libharfbuzz-dev
  libfribidi-dev libfontconfig1-dev libluajit-5.1-dev libsndfile1-dev
  libpulse-dev libbullet-dev libxcb1-dev libxcb-shape0-dev libxcb-keysyms1-dev
  automake libx11-xcb-dev

libc libm libX11 libXext evas ecore ecore-evas ecore-file ecore-ipc ecore-con
  ecore-imf ecore-x edje eet embryo efreet e_dbus eio
  xcb xcb-shape xcb-keysyms
  [png loader in evas, jpeg loader in evas, eet loader in evas, software_x11
  engine in evas, buffer engine in evas]
- your freetype2 version must be > 2.1.7  
  (translation DEPEND or RDEPEND=">=media-libs/freetype-2.1.7\*  and other atoms need to be added in systemd includes !udev so virtual/udev can also satisfy this as non system-d users it will pick one. and you wont incur their hate.... (in this case package depend=rdepend/cdepend or etc many packages use this as a convenience shortcut for devs) 
