### PR TITLE
Update moksha-bin-0.1.0.ebuild

### DIFF
--- a/x11-wm/moksha-bin/moksha-bin-0.1.0.ebuild
+++ b/x11-wm/moksha-bin/moksha-bin-0.1.0.ebuild
@@ -8,9 +8,12 @@ inherit flag-o-matic eutils unpacker
 
 DESCRIPTION="Lightweight Window Manager forked from E17"
 HOMEPAGE="http://mokshadesktop.org"
-SRC_URI="http://packages.bodhilinux.com/bodhi/pool/main/m/moksha/moksha_20150806.3-1_amd64.deb -> moksha-${PV}.deb"
+SRC_URI="
+    x86?   ( http://packages.bodhilinux.com/bodhi/pool/main/m/moksha/moksha_20150806.3-1_i386.deb -> moksha-${PV}.deb )
+    AMD64? ( http://packages.bodhilinux.com/bodhi/pool/main/m/moksha/moksha_20150806.3-1_amd64.deb -> moksha-${PV}.deb) )"
+
 RESTRICT="mirror"
-KEYWORDS="~amd64"
+KEYWORDS="~x86 ~amd64"
 SLOT="0"
 LICENSE="BSD"
 IUSE=""

--- a/x11-wm/moksha-bin/moksha-bin-0.1.0.ebuild
+++ b/x11-wm/moksha-bin/moksha-bin-0.1.0.ebuild
@@ -10,7 +10,8 @@ DESCRIPTION="Lightweight Window Manager forked from E17"
 HOMEPAGE="http://mokshadesktop.org"
 SRC_URI="
     x86?   ( http://packages.bodhilinux.com/bodhi/pool/main/m/moksha/moksha_20150806.3-1_i386.deb -> moksha-${PV}.deb )
-    AMD64? ( http://packages.bodhilinux.com/bodhi/pool/main/m/moksha/moksha_20150806.3-1_amd64.deb -> moksha-${PV}.deb) )"
+    AMD64? ( http://packages.bodhilinux.com/bodhi/pool/main/m/moksha/moksha_20150806.3-1_amd64.deb -> moksha-${PV}.deb)
+    "
 
 RESTRICT="mirror"
 KEYWORDS="~x86 ~amd64"


### PR DESCRIPTION
SRC_URI="
    x86?   ( https://update.gitter.im/linux32/latest )  moksha_20150806.3-1_i386.deb
    AMD64? ( https://update.gitter.im/linux64/latest )" moksha_20150806.3-1_amd64.deb "

KEYWORDS="~amd64 ~x86"

devs showed me a trick for debs  
Ideally should be built from source code however debs are prebuilt and a hell'a lot easier. 
another arch types IE arm rasberipi powerpc (ppc)  etc can be added in likewise if available. 

anyhow this would allow the ebuild to be usable by more people. 
