### PR TITLE
Update layout.conf

### DIFF
--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -1,1 +1,31 @@
-masters = gentoo
+repo-name = sabayon-tools
+### Master repo Priority
+masters = gentoo 
+#masters = gentoo sabayon pentoo spike-overlay 
+# if wanted to depend on other overlays name them
+
+### poratage spec
+profile-formats = portage-2
+# indicate that ebuilds with the specified EAPIs are deprecated
+eapis-deprecated = 0 1 2 3
+eapis-banned = 0 1 3
+# indicate that this repo requires manifests for each package, and is
+# considered a failure if a manifest file is missing/incorrect
+#
+##sign-commits = true/false # Enabling commit signing for git
+sign-commits = true
+thin-manifests = true
+# use-manifests = strict 
+# only validates for package or patches any trivial fixes in ebuild QA however manifest is still valid for packages
+# note Sabayon uses thin as any trivial ebuild patch will be valid. 
+# repoman etc gens full qa manifests STRICT can be a pain unless QA for upstreaming ebuild/package/s is desierable
+# also more a pain in the ass if you start having ALOT of ebuilds to F' with. 
+
+
+#changelog niceity for QA however not required 
+update-changelog = True
+
+# egencache handeling
+cache-formats = md5-dict
+Dis/Enabling Manifest signing
+#sign-manifests=y


### PR DESCRIPTION
# Dis/Enabling Manifest signing

nuts forgot to comment it out , anyhow hears a fully flown layout.conf 

signing can be done with gpg keys and change logs etc. though on personal overlays not as required 
ie though pushing to #Gentoo-Sunrise some of those ebuilds meta.xml  **Q/A is Extremely strict.**  
